### PR TITLE
Added support for Amazon Linux 2 (including tests) 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Test in Debian
-      run: ./test.sh debian
-      
+      run: ./test.sh debian      
+  test-amazonlinux:
+    runs-on: amazonlinux-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Test in Amazonlinux
+      run: ./test.sh amazonlinux

--- a/test.sh
+++ b/test.sh
@@ -38,7 +38,7 @@ test_suite() {
     docker-compose stop -t 1 test-$image_name
 }
 
-images=${*:-"alpine centos ubuntu debian"}
+images=${*:-"alpine centos ubuntu debian amazonlinux"}
 
 for image in $images; do
     test_suite $image

--- a/zsh-in-docker.sh
+++ b/zsh-in-docker.sh
@@ -63,6 +63,14 @@ install_dependencies() {
             $Sudo rpm -i zsh-5.1-1.gf.el7.x86_64.rpm
             $Sudo rm zsh-5.1-1.gf.el7.x86_64.rpm
         ;;
+        amzn)
+            $Sudo yum update
+            $Sudo yum install -y git curl
+            $Sudo yum install -y ncurses-compat-libs # this is required for AMZN Linux (ref: https://github.com/emqx/emqx/issues/2503) 
+            $Sudo curl http://mirror.ghettoforge.org/distributions/gf/el/7/plus/x86_64/zsh-5.1-1.gf.el7.x86_64.rpm > zsh-5.1-1.gf.el7.x86_64.rpm
+            $Sudo rpm -i zsh-5.1-1.gf.el7.x86_64.rpm
+            $Sudo rm zsh-5.1-1.gf.el7.x86_64.rpm
+        ;;
         *)
             $Sudo apt-get update
             $Sudo apt-get -y install git curl zsh locales locales-all


### PR DESCRIPTION
Hey there! Thanks for building this script. I am embedding it into my [shell container](https://github.com/mreferre/eksutils). This PR is to add Amazon Linux 2 support to your script (Amazon Linux 2 is the FROM image I use in my own container) 