### PR TITLE
Removed locales-all installation for ubuntu 14.04

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,11 @@ services:
     entrypoint: /bin/sh
     command: -c "while sleep 1000; do :; done"
 
+  test-ubuntu-14.04:
+    image: ubuntu:14.04
+    entrypoint: /bin/sh
+    command: -c "while sleep 1000; do :; done"
+
   test-debian:
     image: debian:latest
     entrypoint: /bin/sh

--- a/test.sh
+++ b/test.sh
@@ -38,7 +38,7 @@ test_suite() {
     docker-compose stop -t 1 test-$image_name
 }
 
-images=${*:-"alpine centos ubuntu debian amazonlinux"}
+images=${*:-"alpine centos ubuntu ubuntu-14.04 debian amazonlinux"}
 
 for image in $images; do
     test_suite $image

--- a/zsh-in-docker.sh
+++ b/zsh-in-docker.sh
@@ -35,8 +35,16 @@ check_dist() {
     )
 }
 
+check_version() {
+    (
+        . /etc/os-release
+        echo $VERSION_ID
+    )
+}
+
 install_dependencies() {
     DIST=`check_dist`
+    VERSION=`check_version`
     echo "###### Installing dependencies for $DIST"
 
     if [ "`id -u`" = "0" ]; then
@@ -66,7 +74,10 @@ install_dependencies() {
         ;;
         *)
             $Sudo apt-get update
-            $Sudo apt-get -y install git curl zsh locales locales-all
+            $Sudo apt-get -y install git curl zsh locales
+            if [ "$VERSION" != "14.04" ]; then
+                $Sudo apt-get -y install locales-all
+            fi
             $Sudo locale-gen en_US.UTF-8
     esac
 }


### PR DESCRIPTION
I wanted to install zsh on container with ubuntu 14.04, but its repositories don't have package locales-all. So I added os version checking before this package installation. Now it works great for me!