### PR TITLE
Allow user pass their own TERM env

### DIFF
--- a/zsh-in-docker.sh
+++ b/zsh-in-docker.sh
@@ -121,7 +121,7 @@ zshrc_template() {
 export LANG='en_US.UTF-8'
 export LANGUAGE='en_US:en'
 export LC_ALL='en_US.UTF-8'
-export TERM=xterm
+[ -z "$TERM" ] && export TERM=xterm
 
 ##### Zsh/Oh-my-Zsh Configuration
 export ZSH="$_HOME/.oh-my-zsh"


### PR DESCRIPTION
#13 
Now user can pass their own TERM env to enable full color support.
```
docker run -it --env=TERM=xterm-256color image:tag zsh
```