### PR TITLE
Add centos to zsh-in-docker.sh for package installation

### DIFF
--- a/zsh-in-docker.sh
+++ b/zsh-in-docker.sh
@@ -94,7 +94,7 @@ install_dependencies() {
             $Sudo yum install -y git zsh
             $Sudo yum install -y ncurses-compat-libs # this is required for AMZN Linux (ref: https://github.com/emqx/emqx/issues/2503)
         ;;
-        rhel|fedora|rocky)
+        rhel|fedora|rocky|centos)
             $Sudo yum update -y
             $Sudo yum install -y git zsh
         ;;


### PR DESCRIPTION
Add the CentOS switch back to support CentOS Stream 9 for the dependencies package installation.
Fix: #32 